### PR TITLE
WAZO-756 conference list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+19.08
+-----
+
+* A new resource has been added to list contacts from the `conference` backend
+
+  * GET `/0.1/backends/conference/sources/<source_uuid>/contacts`
+
+
 19.07
 -----
 

--- a/integration_tests/assets/etc/wazo-dird/conf.d/asset.wazo_users_multiple_wazo.yml
+++ b/integration_tests/assets/etc/wazo-dird/conf.d/asset.wazo_users_multiple_wazo.yml
@@ -2,6 +2,7 @@ enabled_plugins:
   backends:
     wazo: true
   views:
+    conference_view: true
     default_json: true
     wazo_backend: true
     sources_view: true

--- a/integration_tests/suite/helpers/config.py
+++ b/integration_tests/suite/helpers/config.py
@@ -146,6 +146,14 @@ def new_conference_config(Session):
         confd={'host': 'america', 'port': 9486, 'https': False},
         searched_columns=['name'],
     )
+    config.with_source(
+        tenant_uuid=SUB_TENANT,
+        backend='conference',
+        name='confs_sub',
+        auth={'host': 'auth', 'username': 'foo', 'password': 'bar', 'verify_certificate': False},
+        confd={'host': 'america', 'port': 9486, 'https': False},
+        searched_columns=['name'],
+    )
     config.with_profile(
         name='default',
         display='default_display',

--- a/integration_tests/suite/test_conference_contacts.py
+++ b/integration_tests/suite/test_conference_contacts.py
@@ -1,0 +1,87 @@
+# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from hamcrest import (
+    assert_that,
+    calling,
+    has_properties,
+)
+
+from xivo_test_helpers.hamcrest.raises import raises
+
+from .helpers.base import BaseDirdIntegrationTest
+from .helpers.config import new_conference_config
+from .helpers.constants import (
+    MAIN_TENANT,
+    SUB_TENANT,
+    UNKNOWN_UUID,
+    VALID_TOKEN_MAIN_TENANT,
+    VALID_TOKEN_SUB_TENANT,
+)
+
+BACKEND = 'conference'
+
+
+class TestConferenceContactList(BaseDirdIntegrationTest):
+
+    asset = 'wazo_users_multiple_wazo'
+    config_factory = new_conference_config
+
+    def setUp(self):
+        super().setUp()
+        for source in self.client.sources.list(backend='conference', recurse=True)['items']:
+            if source['name'] == 'confs':
+                self.source_uuid = source['uuid']
+            elif source['name'] == 'confs_sub':
+                self.sub_source_uuid = source['uuid']
+
+    def test_with_an_unknown_source(self):
+        assert_that(
+            calling(self.contacts).with_args(self.client, UNKNOWN_UUID),
+            raises(Exception).matching(has_properties(response=has_properties(status_code=404))),
+        )
+
+    def test_multi_tenant(self):
+        main_tenant_client = self.get_client(VALID_TOKEN_MAIN_TENANT)
+        sub_tenant_client = self.get_client(VALID_TOKEN_SUB_TENANT)
+
+        assert_that(
+            calling(self.contacts).with_args(sub_tenant_client, self.source_uuid),
+            raises(Exception).matching(has_properties(response=has_properties(status_code=404))),
+        )
+
+        assert_that(
+            calling(self.contacts).with_args(
+                sub_tenant_client,
+                self.source_uuid,
+                tenant_uuid=MAIN_TENANT
+            ),
+            raises(Exception).matching(has_properties(response=has_properties(status_code=401))),
+        )
+
+        assert_that(
+            calling(self.contacts).with_args(
+                main_tenant_client,
+                self.source_uuid,
+                tenant_uuid=SUB_TENANT,
+            ),
+            raises(Exception).matching(has_properties(response=has_properties(status_code=404))),
+        )
+
+    def test_with_no_confd(self):
+        self.stop_service('america')
+        try:
+            assert_that(
+                calling(self.contacts).with_args(self.client, self.source_uuid),
+                raises(Exception).matching(has_properties(response=has_properties(status_code=503)))
+            )
+        finally:
+            self.start_service('america')
+
+    def contacts(self, client, uuid, *args, **kwargs):
+        return client.backends.list_contacts_from_source(
+            backend=BACKEND,
+            source_uuid=uuid,
+            *args,
+            **kwargs
+        )

--- a/wazo_dird/plugins/conference_backend/api.yml
+++ b/wazo_dird/plugins/conference_backend/api.yml
@@ -6,6 +6,7 @@ paths:
       description: '**Required ACL:** dird.backends.conference.sources.read'
       tags:
         - configuration
+        - conference
       parameters:
         - $ref: '#/parameters/tenantuuid'
         - $ref: '#/parameters/recurse'
@@ -24,6 +25,7 @@ paths:
       description: '**Required ACL:** `dird.backends.conference.sources.create`'
       tags:
         - configuration
+        - conference
       parameters:
         - $ref: '#/parameters/tenantuuid'
         - name: body
@@ -60,6 +62,7 @@ paths:
       description: '**Required ACL:** `dird.backends.conference.sources.{source_uuid}.read`'
       tags:
         - configuration
+        - conference
       parameters:
         - $ref: '#/parameters/tenantuuid'
         - $ref: '#/parameters/sourceuuid'
@@ -76,6 +79,7 @@ paths:
       description: '**Required ACL:** `dird.backends.conference.sources.{source_uuid}.update`'
       tags:
         - configuration
+        - conference
       parameters:
         - $ref: '#/parameters/tenantuuid'
         - $ref: '#/parameters/sourceuuid'
@@ -102,6 +106,7 @@ paths:
       description: '**Required ACL:** `dird.backends.conference.sources.{source_uuid}.delete`'
       tags:
         - configuration
+        - conference
       parameters:
         - $ref: '#/parameters/tenantuuid'
         - $ref: '#/parameters/sourceuuid'
@@ -110,7 +115,79 @@ paths:
           $ref: '#/responses/ResourceDeleted'
         '404':
           $ref: '#/responses/NotFoundError'
+  /backends/conference/sources/{source_uuid}/contacts:
+    get:
+      description: '**Required ACL:** `dird.backends.conference.sources.{source_uuid}.contacts.read`'
+      operationId: list_contacts from source
+      parameters:
+        - $ref: '#/parameters/tenantuuid'
+        - in: path
+          name: source_uuid
+          required: true
+          description: Source uuid
+          type: string
+        - $ref: '#/parameters/order'
+        - $ref: '#/parameters/direction'
+        - $ref: '#/parameters/limit'
+        - $ref: '#/parameters/offset'
+        - $ref: '#/parameters/search'
+      summary: Retrieve all contacts from a conference source
+      tags:
+        - conference
+      responses:
+        '200':
+          description: Contacts as fetched from the Wazo engine.
+          schema:
+            $ref: '#/definitions/ConferenceContactList'
+        '401':
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/Error'
+        '404':
+          description: No such source
+          schema:
+            $ref: '#/definitions/Error'
+        '503':
+          description: Another service is unavailable (e.g. wazo-auth, xivo-confd, ...)
+          schema:
+            $ref: '#/definitions/Error'
 definitions:
+  ConferenceContact:
+    properties:
+      uuid:
+        type: string
+        description: The UUID of the contact
+      name:
+        type: string
+        description: The lastname of the contact
+      extensions:
+        type: array
+        items:
+          type: string
+          description: The internal number of that contact
+      incalls:
+        type: array
+        items:
+          type: string
+          description: The external number of that contact
+  ConferenceContactList:
+    properties:
+      total:
+        type: integer
+        description: The number of contacts in this source
+        readOnly: true
+      filtered:
+        type: integer
+        description: The number of contacts in this source (filtered is not implemented)
+        readOnly: True
+      items:
+        type: array
+        items:
+          $ref: '#/definitions/ConferenceContact'
+    required:
+      - items
+      - total
+      - filtered
   ConferenceSource:
     title: ConferenceSource
     allOf:

--- a/wazo_dird/plugins/conference_backend/http.py
+++ b/wazo_dird/plugins/conference_backend/http.py
@@ -1,16 +1,23 @@
 # Copyright 2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from flask import request
+from xivo.tenant_flask_helpers import Tenant
+
 from wazo_dird.helpers import (
     SourceItem,
     SourceList,
 )
 from wazo_dird.auth import required_acl
+from wazo_dird.rest_api import AuthResource
+from wazo_dird.plugin_helpers.confd_client_registry import registry
 
 from .schemas import (
+    contact_list_param_schema,
+    contact_list_schema,
     list_schema,
-    source_schema,
     source_list_schema,
+    source_schema,
 )
 
 
@@ -44,3 +51,25 @@ class ConferenceItem(SourceItem):
     @required_acl('dird.backends.conference.sources.{source_uuid}.update')
     def put(self, source_uuid):
         return super().put(source_uuid)
+
+
+class ConferenceContactList(AuthResource):
+
+    def __init__(self, source_service):
+        self._source_service = source_service
+
+    @required_acl('dird.backends.conference.sources.{source_uuid}.contacts.read')
+    def get(self, source_uuid):
+        tenant_uuid = Tenant.autodetect().uuid
+        visible_tenants = self.get_visible_tenants(tenant_uuid)
+        list_params = contact_list_param_schema.load(request.args).data
+        source_config = self._source_service.get('conference', source_uuid, visible_tenants)
+
+        confd = registry.get(source_config)
+        response = confd.conferences.list(**list_params)
+
+        return {
+            'total': response['total'],
+            'filtered': response['total'],
+            'items': contact_list_schema.dump(response['items']).data,
+        }

--- a/wazo_dird/plugins/conference_backend/http.py
+++ b/wazo_dird/plugins/conference_backend/http.py
@@ -4,6 +4,7 @@
 from flask import request
 from xivo.tenant_flask_helpers import Tenant
 
+from wazo_dird import exception
 from wazo_dird.helpers import (
     SourceItem,
     SourceList,
@@ -66,7 +67,10 @@ class ConferenceContactList(AuthResource):
         source_config = self._source_service.get('conference', source_uuid, visible_tenants)
 
         confd = registry.get(source_config)
-        response = confd.conferences.list(**list_params)
+        try:
+            response = confd.conferences.list(**list_params)
+        except Exception as e:
+            raise exception.XiVOConfdError(confd, e)
 
         return {
             'total': response['total'],

--- a/wazo_dird/plugins/conference_backend/plugin.py
+++ b/wazo_dird/plugins/conference_backend/plugin.py
@@ -34,7 +34,7 @@ class ConferenceViewPlugin(BaseBackendView):
         api.add_resource(
             self.contact_list_resource,
             "/backends/conference/sources/<source_uuid>/contacts",
-            resource_class_args=((source_service,)),
+            resource_class_args=(source_service,),
         )
 
     def unload(self):

--- a/wazo_dird/plugins/conference_backend/plugin.py
+++ b/wazo_dird/plugins/conference_backend/plugin.py
@@ -33,7 +33,7 @@ class ConferenceViewPlugin(BaseBackendView):
 
         api.add_resource(
             self.contact_list_resource,
-            "/backends/conference/sources/<source_uuid>/contacts",
+            '/backends/conference/sources/<source_uuid>/contacts',
             resource_class_args=(source_service,),
         )
 

--- a/wazo_dird/plugins/conference_backend/plugin.py
+++ b/wazo_dird/plugins/conference_backend/plugin.py
@@ -24,6 +24,21 @@ class ConferenceViewPlugin(BaseBackendView):
     backend = 'conference'
     list_resource = http.ConferenceList
     item_resource = http.ConferenceItem
+    contact_list_resource = http.ConferenceContactList
+
+    def load(self, dependencies):
+        super().load(dependencies)
+        api = dependencies['api']
+        source_service = dependencies['services']['source']
+
+        api.add_resource(
+            self.contact_list_resource,
+            "/backends/conference/sources/<source_uuid>/contacts",
+            resource_class_args=((source_service,)),
+        )
+
+    def unload(self):
+        registry.unregister_all()
 
 
 class ConferencePlugin(BaseSourcePlugin):

--- a/wazo_dird/plugins/conference_backend/schemas.py
+++ b/wazo_dird/plugins/conference_backend/schemas.py
@@ -1,13 +1,53 @@
 # Copyright 2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from marshmallow import pre_dump
+
 from xivo.mallow import fields
 from xivo.mallow_helpers import ListSchema as _ListSchema
 from wazo_dird.schemas import (
     AuthConfigSchema,
+    BaseSchema,
     BaseSourceSchema,
     ConfdConfigSchema,
 )
+
+
+class ExtensionSchema(BaseSchema):
+    context = fields.String()
+    exten = fields.String()
+
+
+class ContactSchema(BaseSchema):
+    id = fields.Integer()
+    name = fields.String()
+    extensions = fields.Nested(ExtensionSchema, many=True)
+    incalls = fields.Nested(ExtensionSchema, many=True)
+
+    @pre_dump(pass_many=True)
+    def unpack_extensions(self, data, many):
+        extension_schema = ExtensionSchema(many=True)
+        for contact in data:
+            incalls = []
+
+            extensions = extension_schema.dump(contact['extensions']).data
+
+            for incall in contact['incalls']:
+                incalls += extension_schema.dump(incall['extensions']).data
+
+            contact['extensions'] = extensions
+            contact['incalls'] = incalls
+
+        return data
+
+
+class ContactListSchema(_ListSchema):
+
+    searchable_columns = ['id', 'name']
+    sort_columns = ['name']
+    default_sort_column = 'name'
+
+    recurse = fields.Boolean(missing=False)
 
 
 class ListSchema(_ListSchema):
@@ -24,6 +64,8 @@ class SourceSchema(BaseSourceSchema):
     confd = fields.Nested(ConfdConfigSchema, missing={})
 
 
+contact_list_schema = ContactSchema(many=True)
+contact_list_param_schema = ContactListSchema()
 source_schema = SourceSchema()
 source_list_schema = SourceSchema(many=True)
 list_schema = ListSchema()

--- a/wazo_dird/plugins/conference_backend/tests/test_schemas.py
+++ b/wazo_dird/plugins/conference_backend/tests/test_schemas.py
@@ -19,10 +19,10 @@ class TestContactSchema(TestCase):
     def test_dump(self):
         raw = [
             {
-                "id": 3,
-                "name": "minimal",
-                "extensions": [],
-                "incalls": [
+                'id': 3,
+                'name': 'minimal',
+                'extensions': [],
+                'incalls': [
                     {
                         'extensions': [
                             {
@@ -38,9 +38,9 @@ class TestContactSchema(TestCase):
                 ],
             },
             {
-                "id": 1,
-                "name": "test",
-                "extensions": [
+                'id': 1,
+                'name': 'test',
+                'extensions': [
                     {
                         'exten': '4001',
                         'context': 'inside',
@@ -48,7 +48,7 @@ class TestContactSchema(TestCase):
                         'links': [{'rel': 'extensions', 'href': '.../extensions/57'}],
                     },
                 ],
-                "incalls": [
+                'incalls': [
                     {
                         'extensions': [
                             {

--- a/wazo_dird/plugins/conference_backend/tests/test_schemas.py
+++ b/wazo_dird/plugins/conference_backend/tests/test_schemas.py
@@ -1,0 +1,83 @@
+# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from unittest import TestCase
+
+from hamcrest import (
+    assert_that,
+    contains,
+    contains_inanyorder,
+    empty,
+    has_entries,
+)
+
+from ..schemas import contact_list_schema
+
+
+class TestContactSchema(TestCase):
+
+    def test_dump(self):
+        raw = [
+            {
+                "id": 3,
+                "name": "minimal",
+                "extensions": [],
+                "incalls": [
+                    {
+                        'extensions': [
+                            {
+                                'exten': '4001',
+                                'context': 'from-extern',
+                                'id': 77,
+                                'links': [{'rel': 'extensions', 'href': '.../extensions/77'}],
+                            },
+                        ],
+                        'id': 14,
+                        'links': [{'rel': 'incalls', 'href': '.../incalls/14'}]
+                    },
+                ],
+            },
+            {
+                "id": 1,
+                "name": "test",
+                "extensions": [
+                    {
+                        'exten': '4001',
+                        'context': 'inside',
+                        'id': 57,
+                        'links': [{'rel': 'extensions', 'href': '.../extensions/57'}],
+                    },
+                ],
+                "incalls": [
+                    {
+                        'extensions': [
+                            {
+                                'exten': '1009',
+                                'context': 'from-extern',
+                                'id': 76,
+                                'links': [{'rel': 'extensions', 'href': '.../extensions/76'}],
+                            },
+                        ],
+                        'id': 13,
+                        'links': [{'rel': 'incalls', 'href': '.../incalls/13'}],
+                    },
+                ],
+            },
+        ]
+
+        result = contact_list_schema.dump(raw).data
+
+        assert_that(result, contains_inanyorder(
+            has_entries(
+                id=3,
+                name='minimal',
+                extensions=empty(),
+                incalls=contains(has_entries(exten='4001')),
+            ),
+            has_entries(
+                id=1,
+                name='test',
+                extensions=contains(has_entries(exten='4001')),
+                incalls=contains(has_entries(exten='1009')),
+            ),
+        ))


### PR DESCRIPTION
This branch adds the ability to list conference rooms that are configured on an wazo-platform and that are available to a user.

this resource is meant to be used in conjunction with the `/directories/<profile>/sources` which lists the sources that are available to the user.