### PR TITLE
use openapi-spec-validator instead of swagger-validator

### DIFF
--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -6,7 +6,6 @@ test-setup: egg-info build-dird build-db-image
 	docker pull p0bailey/docker-flask
 	docker pull python:2.7.13-stretch
 	docker pull rabbitmq
-	docker pull swaggerapi/swagger-validator
 	docker pull wazopbx/wait
 	docker pull wazopbx/wazo-auth-mock
 

--- a/integration_tests/assets/docker-compose.documentation.override.yml
+++ b/integration_tests/assets/docker-compose.documentation.override.yml
@@ -3,11 +3,5 @@ services:
   sync:
     depends_on:
       - dird
-      - swagger-validator
     environment:
-      TARGETS: "dird:9489 swagger-validator:8080"
-
-  swagger-validator:
-    image: swaggerapi/swagger-validator
-    ports:
-      - "8080"
+      TARGETS: "dird:9489"

--- a/integration_tests/suite/test_documentation.py
+++ b/integration_tests/suite/test_documentation.py
@@ -1,12 +1,17 @@
 # Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import logging
 import requests
-import pprint
+import yaml
 
-from hamcrest import assert_that, empty
+from openapi_spec_validator import validate_v2_spec
 
 from .helpers.base import DirdAssetRunningTestCase
+
+
+logger = logging.getLogger('openapi_spec_validator')
+logger.setLevel(logging.INFO)
 
 
 class TestDocumentation(DirdAssetRunningTestCase):
@@ -14,13 +19,7 @@ class TestDocumentation(DirdAssetRunningTestCase):
     asset = 'documentation'
 
     def test_documentation_errors(self):
-        dird_port = self.service_port(9489, 'dird')
-        api_url = 'https://localhost:{port}/0.1/api/api.yml'.format(port=dird_port)
+        port = self.service_port(9489, 'dird')
+        api_url = 'https://localhost:{port}/0.1/api/api.yml'.format(port=port)
         api = requests.get(api_url, verify=False)
-        self.validate_api(api)
-
-    def validate_api(self, api):
-        validator_port = self.service_port(8080, 'swagger-validator')
-        validator_url = 'http://localhost:{port}/debug'.format(port=validator_port)
-        response = requests.post(validator_url, data=api)
-        assert_that(response.json(), empty(), pprint.pformat(response.json()))
+        validate_v2_spec(yaml.safe_load(api.text))

--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -5,6 +5,7 @@ https://github.com/wazo-pbx/xivo-lib-python/archive/master.zip
 babel
 flask-babel
 docker-compose
+openapi-spec-validator
 pyhamcrest
 # pytest 4.2.0 has a bug: https://github.com/pytest-dev/pytest/issues/4700
 pytest!=4.2.0

--- a/wazo_dird/plugins/conference_backend/api.yml
+++ b/wazo_dird/plugins/conference_backend/api.yml
@@ -3,7 +3,7 @@ paths:
     get:
       operationId: list_conference_sources
       summary: Get all `conference` source configurations
-      description: '**Required ACL:** dird.backends.conference.sources.read'
+      description: '**Required ACL:** `dird.backends.conference.sources.read`'
       tags:
         - configuration
         - conference


### PR DESCRIPTION
reason: openapi-spec-validator catches more errors