### PR TITLE
wazo user contact list: add the id field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+19.09
+-----
+
+* The `id` column has been added to the `wazo` contact list
+
+
 19.08
 -----
 

--- a/integration_tests/suite/test_wazo_user_contacts.py
+++ b/integration_tests/suite/test_wazo_user_contacts.py
@@ -46,6 +46,7 @@ class TestWazoContactList(BaseDirdIntegrationTest):
             filtered=4,
             items=contains_inanyorder(
                 has_entries(
+                    id=1,
                     uuid=uuid_(),
                     firstname='John',
                     lastname='Doe',
@@ -61,6 +62,7 @@ class TestWazoContactList(BaseDirdIntegrationTest):
         ))
 
         assert_that(result['items'][0].keys(), contains_inanyorder(
+            'id',
             'uuid',
             'firstname',
             'lastname',

--- a/wazo_dird/plugins/wazo_user_backend/api.yml
+++ b/wazo_dird/plugins/wazo_user_backend/api.yml
@@ -149,6 +149,9 @@ paths:
 definitions:
   WazoContact:
     properties:
+      id:
+        type: integer
+        description: The ID of the contact which is used to favorite that contact
       uuid:
         type: string
         description: The UUID of the contact

--- a/wazo_dird/plugins/wazo_user_backend/schemas.py
+++ b/wazo_dird/plugins/wazo_user_backend/schemas.py
@@ -35,6 +35,7 @@ class ContactListSchema(_ListSchema):
 
 
 class ContactSchema(BaseSchema):
+    id = fields.Integer()
     uuid = fields.String()
     firstname = fields.String()
     lastname = fields.String()


### PR DESCRIPTION
The "id" is required to be able to set the contact as a favorite because when
doing a GET /lookup the source_entry_id is mapped to the "id" column