### PR TITLE
token_renewer: use new callback signature

### DIFF
--- a/wazo_dird/controller.py
+++ b/wazo_dird/controller.py
@@ -36,7 +36,9 @@ class Controller:
         auth.set_auth_config(self.config['auth'])
         self.auth_client = AuthClient(**self.config['auth'])
         self.token_renewer = TokenRenewer(self.auth_client)
-        self.token_renewer.subscribe_to_token_change(self.auth_client.set_token)
+        self.token_renewer.subscribe_to_token_change(
+            lambda token: self.auth_client.set_token(token['token'])
+        )
         self.status_aggregator = StatusAggregator()
         self._service_registration_params = [
             'wazo-dird',

--- a/wazo_dird/plugin_helpers/confd_client_registry.py
+++ b/wazo_dird/plugin_helpers/confd_client_registry.py
@@ -56,7 +56,9 @@ class _Registry:
         client = ConfdClient(**confd_config)
         client.set_tenant(source_config['tenant_uuid'])
 
-        token_renewer.subscribe_to_token_change(client.set_token)
+        token_renewer.subscribe_to_token_change(
+            lambda token: client.set_token(token['token'])
+        )
         token_renewer.start()
 
         self._clients[source_config['uuid']] = RegisteredClient(client, token_renewer)


### PR DESCRIPTION
token_renewer now passes the whole token object to callbacks